### PR TITLE
fix: ignore client_id validation

### DIFF
--- a/services/Providers.js
+++ b/services/Providers.js
@@ -19,7 +19,7 @@ const getCognitoPayload = async (idToken) => {
   const verifier = CognitoJwtVerifier.create({
     userPoolId: process.env.COGNITO_POOL_ID,
     tokenUse: "id",
-    clientId: process.env.COGNITO_CLIENT_ID,
+    clientId: null,
   });
 
   try {


### PR DESCRIPTION
Motivation:
- To allow strapi accept client_id from more than one service, like end-user and CP platform,

Changes
- Change the client_id configuration to avoid validate it